### PR TITLE
add sleep 0.1 after start_auto_serial_reading

### DIFF
--- a/pykeigan/usbcontroller.py
+++ b/pykeigan/usbcontroller.py
@@ -47,6 +47,7 @@ class USBController(base.Controller):
         #print('-- precheck reading value')
         try:
             self.start_auto_serial_reading()
+            time.sleep(0.1)
             self._read_setting_value(0x46)#motor_name
             self._read_setting_value(0x47)#motor_info
             


### PR DESCRIPTION
`usbcontroller.USBController` の初期化時に行う `self.start_auto_serial_reading()` の実行後に `self._read_setting_value(0x46)` または `self._read_setting_value(0x47)`  で下記のエラーが発生していました。下記エラーの対応PRになります。

```
>>> from pykeigan import usbcontroller
>>> a = usbcontroller.USBController('/dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_DM00KX9H-if00-port0')
Precheck error: No data received
        attemping to reconnect...
...reconnecting...
```

`self.start_auto_serial_reading()`実行後に0.1秒のスリープを入れたところ改善しましたので、モーター側のシリアル送信の初期化中にシリアル通信の内容を読み取る処理を行っていたためデータを受け取れずエラーになっていたかと思われます。